### PR TITLE
fix(eslint): enable padding-line-between-statements

### DIFF
--- a/packages/node_modules/@webex/eslint-config-base/rules/style.js
+++ b/packages/node_modules/@webex/eslint-config-base/rules/style.js
@@ -383,7 +383,11 @@ module.exports = {
 
     // Require or disallow padding lines between statements
     // https://eslint.org/docs/rules/padding-line-between-statements
-    'padding-line-between-statements': 'off',
+    'padding-line-between-statements': ['error',
+      {blankLine: 'always', prev: '*', next: 'return'},
+      {blankLine: 'always', prev: ['const', 'let', 'var'], next: '*'},
+      {blankLine: 'any', prev: ['const', 'let', 'var'], next: ['const', 'let', 'var']}
+    ],
 
     // require quotes around object literal property names
     // https://eslint.org/docs/rules/quote-props.html


### PR DESCRIPTION
We have this listed as a requirement in the [readme docs](https://github.com/webex/web-styleguide/blob/5cdbd86359b6cb01266898761f6fb3b77f95d756/javascript/README.md#whitespace--after-blocks) but it wasn't actually enabled in the eslint config.