### PR TITLE
feat(markdownlint): change ordered list rule

### DIFF
--- a/linters/.markdownlint.json
+++ b/linters/.markdownlint.json
@@ -95,7 +95,7 @@
 
   "comment": "MD029: Ordered list item prefix",
   "ol-prefix": {
-    "style": "one"
+    "style": "one_or_ordered"
   },
 
   "comment": "MD030: Spaces after list markers",


### PR DESCRIPTION
This allows actually numbered lists in addition to "one"
https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md029

The rule we have in place requires ordered lists in markdown to be numbered like:

```markdown
1. one
1. two
1. three
```

This change allows you to actually number lists:

```markdown
1. one
2. two
3. three
```